### PR TITLE
fix ci testcases

### DIFF
--- a/Tests/AssetQueryAPITest.swift
+++ b/Tests/AssetQueryAPITest.swift
@@ -61,7 +61,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test02Find_AssetQuery_whereUIDEquals() async {
@@ -77,7 +77,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test03Find_AssetQuery_whereTitleDNotEquals() async {
@@ -93,7 +93,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test03Find_AssetQuery_whereFileNameEquals() async {
@@ -109,7 +109,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test04Find_AssetQuery_whereFileNameexists() async {
@@ -123,7 +123,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test05Find_AssetQuery_whereTitleMatchRegex() async {
@@ -137,7 +137,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test06Fetch_Asset_fromUID() async {
@@ -151,7 +151,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test07Fetch_AssetQuery_WithDimentsions() async {
@@ -169,7 +169,7 @@ class AssetQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
     
@@ -186,7 +186,7 @@ class AssetQueryAPITest: XCTestCase {
                 }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test09Fetch_AssetQuery_WithCount() async {
@@ -203,7 +203,7 @@ class AssetQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -221,7 +221,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test12Fetch_AssetQuery_WithoutFallback_Result() async {
@@ -242,7 +242,7 @@ class AssetQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
             }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test13Fetch_AssetQuery_Fallback_Result() async {
@@ -275,7 +275,7 @@ class AssetQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
             }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test14Fetch_Asset_UIDWithoutFallback_NoResult() async {
@@ -294,7 +294,7 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test15Fetch_Asset_UIDWithFallback_NoResult() async {
@@ -315,6 +315,6 @@ class AssetQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 }

--- a/Tests/ContentTypeQueryAPITest.swift
+++ b/Tests/ContentTypeQueryAPITest.swift
@@ -56,7 +56,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test02Find_ContentTypeQuery_whereUIDEquals() async {
@@ -72,7 +72,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test03Find_ContentTypeQuery_whereTitleDNotEquals()  async {
@@ -88,7 +88,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test04Find_ContentTypeQuery_whereDescriptionexists() async {
@@ -102,7 +102,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test05Find_ContentTypeQuery_whereTitleMatchRegex() async {
@@ -116,7 +116,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test06Fetch_ContentType_fromUID() async {
@@ -130,7 +130,7 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test07Fetch_ContentTypeQuery_WithGlobalFields() async {
@@ -154,7 +154,7 @@ class ContentTypeQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
     
@@ -176,7 +176,7 @@ class ContentTypeQueryAPITest: XCTestCase {
                 }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test09Fetch_ContentTypeQuery_WithCount() async {
@@ -192,7 +192,7 @@ class ContentTypeQueryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -210,6 +210,6 @@ class ContentTypeQueryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 }

--- a/Tests/EntryAPITest.swift
+++ b/Tests/EntryAPITest.swift
@@ -56,7 +56,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test02Find_EntryQuery_whereUIDEquals() async {
@@ -72,7 +72,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test03Find_EntryQuery_whereTitleDNotEquals() async {
@@ -88,7 +88,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test04Find_EntryQuery_whereTitleexists() async {
@@ -102,7 +102,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func testtest05Find_EntryQuery_whereTitleMatchRegex() async {
@@ -116,7 +116,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test06Fetch_Entry_fromUID() async {
@@ -130,7 +130,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test07Fetch_EntryQuery_WithIncludeContentType() async {
@@ -146,7 +146,7 @@ class EntryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
     
@@ -170,7 +170,7 @@ class EntryAPITest: XCTestCase {
                 }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test09Fetch_EntryQuery_WithCount() async {
@@ -186,7 +186,7 @@ class EntryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -203,7 +203,7 @@ class EntryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test11Fetch_Entry_WithWrongUID_shouldFail() async {
@@ -221,7 +221,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test12Fetch_EntryQuery_WithGlobalFields() async {
@@ -244,7 +244,7 @@ class EntryAPITest: XCTestCase {
                 }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test13Find_EntryQuery_whereTitleIncludes() async {
@@ -264,7 +264,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test14Find_EntryQuery_whereTitleExclude()  async {
@@ -284,7 +284,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test15Find_EntryQuery_wherelessThan() async {
@@ -681,7 +681,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func test25Find_EntryQuery_ExcludeFields() async {
@@ -706,7 +706,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 
     func testtest26Find_EntryQuery_IncludeReference() async {
@@ -736,7 +736,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -763,7 +763,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
     func test28Find_EntryQuery_IncludeReferenceOnly() async {
@@ -791,7 +791,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -819,7 +819,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
     func test30Find_EntryQuery_IncludeReferenceExceot() async {
@@ -847,7 +847,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
 
     }
 
@@ -874,7 +874,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30)
 
     }
     
@@ -896,7 +896,7 @@ class EntryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
             }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30)
     }
     
     func test33Fetch_EntryQuery_Fallback_Result() async {
@@ -929,7 +929,7 @@ class EntryAPITest: XCTestCase {
                 }
                 networkExpectation.fulfill()
             }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test34Fetch_Entry_UIDWithoutFallback_NoResult() async {
@@ -948,7 +948,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test35Fetch_Entry_UIDWithFallback_NoResult() async {
@@ -967,7 +967,7 @@ class EntryAPITest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
 }

--- a/Tests/GlobalFieldAPITest.swift
+++ b/Tests/GlobalFieldAPITest.swift
@@ -52,7 +52,7 @@ class GlobalFieldAPITest: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30.0)
     }
 
     func test02FetchSingleGlobalField() async {
@@ -78,7 +78,7 @@ class GlobalFieldAPITest: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30.0)
     }
 
     func test03FetchGlobalFieldsWithBranch() async {
@@ -96,7 +96,7 @@ class GlobalFieldAPITest: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30.0)
     }
 
     func test04FetchGlobalFieldWithSchema() async {
@@ -114,6 +114,6 @@ class GlobalFieldAPITest: XCTestCase {
                 }
                 expectation.fulfill()
             }
-        wait(for: [expectation], timeout: 30)
+        await fulfillment(of: [expectation], timeout: 30.0)
     }
 }

--- a/Tests/QueryOnAPITest.swift
+++ b/Tests/QueryOnAPITest.swift
@@ -49,7 +49,7 @@
 //                }
 //                networkExpectation.fulfill()
 //            }
-//        wait(for: [networkExpectation], timeout: 30)
+//        await fulfillment(of: [networkExpectation], timeout: 30.0)
 //
 //    }
 //    
@@ -75,7 +75,7 @@
 //            }
 //            networkExpectation.fulfill()
 //        }
-//        wait(for: [networkExpectation], timeout: 30)
+//        await fulfillment(of: [networkExpectation], timeout: 30.0)
 //
 //    }
 //

--- a/Tests/TaxonomyTest.swift
+++ b/Tests/TaxonomyTest.swift
@@ -49,7 +49,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test02Find_TaxonomyQuery_AndOperator() async {
@@ -66,7 +66,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test03Find_TaxonomyQuery_InOperator() async {
@@ -81,7 +81,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test04Find_TaxonomyQuery_Below() async {
@@ -96,7 +96,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test05Find_TaxonomyQuery_EqBelow() async {
@@ -111,7 +111,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test06Find_TaxonomyQuery_Above() async {
@@ -126,7 +126,7 @@ class TaxonomyTest: XCTestCase {
             }
             networkExpectation.fulfill()
         }
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
     
     func test07Find_TaxonomyQuery_EqAbove() async {
@@ -142,6 +142,6 @@ class TaxonomyTest: XCTestCase {
             networkExpectation.fulfill()
         }
         
-        wait(for: [networkExpectation], timeout: 30)
+        await fulfillment(of: [networkExpectation], timeout: 30.0)
     }
 }


### PR DESCRIPTION
Refactor asynchronous test timeout handling to use await fulfillment for improved clarity and consistency across test files.