### PR TITLE
Update CHANGELOG and README to announce deprecation of CocoaPods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v2.3.3
+
+### Date: 02-Apr-2026
+
+### Documentation
+
+- Announced deprecation of **CocoaPods** as the recommended distribution for the Contentstack Swift SDK; **Swift Package Manager** is recommended for new integrations. Updated [README.md](README.md), [Docs/overview.md](Docs/overview.md), and [DEPRECATION.md](DEPRECATION.md).
+
 ## v2.3.2
 
 ### Date: 12-Jan-2026

--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -1,0 +1,33 @@
+# CocoaPods and the Contentstack Swift SDK
+
+This page explains how **CocoaPods** fits into our story for the **Contentstack Swift SDK** (`ContentstackSwift`). It is written for **app developers** integrating the Content Delivery API on Apple platforms.
+
+## Summary
+
+- **The Swift SDK is not deprecated.** This repo continues to ship the supported Swift CDA client.
+- We are **deprecating CocoaPods as the recommended way to consume** that SDK. **Swift Package Manager (SPM)** is what we recommend for **new** projects.
+- If you already use the pod, you can **keep using it** until you choose to move to SPM.
+
+## What to use
+
+| You want to… | Use this |
+|----------------|----------|
+| Start a **new** integration | **SPM** — see [Swift Package Index](https://swiftpackageindex.com/contentstack/contentstack-swift) or add `https://github.com/contentstack/contentstack-swift` in Xcode (**File → Add Package Dependencies…**). |
+| Read API docs | [Swift Content Delivery SDK reference](https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/swift/reference) |
+| Browse source and tags | [contentstack-swift on GitHub](https://github.com/contentstack/contentstack-swift) |
+
+## Existing CocoaPods users
+
+No forced migration deadline is implied here. Projects that already depend on `ContentstackSwift` via CocoaPods can continue to ship. When you are ready, remove the pod and add the same library through SPM using the GitHub URL above.
+
+## Why SPM for new work
+
+The CocoaPods ecosystem has shifted toward maintenance and archived specs ([CocoaPods Specs repo — industry context](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)). **SPM** is the default for most new Swift and Apple-platform codebases, and it is where we focus **new** documentation and examples. The CocoaPods spec may still receive **maintenance** updates for a time; **SPM should be your first choice** for new apps and modules.
+
+## Help
+
+Questions about the product or your stack: [Contentstack support](https://www.contentstack.com/support).
+
+---
+
+*Last updated: April 2026*

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 # Contentstack Swift SDK
 ![Contentstack CI](https://github.com/contentstack/contentstack-swift/workflows/Contentstack%20CI/badge.svg)
 
+## Important
+
+This repo is the supported **Contentstack Swift SDK** for the Content Delivery API. **Use Swift Package Manager (SPM) for new projects.** The **`ContentstackSwift`** CocoaPods distribution is **deprecated for new integrations**—prefer SPM. That applies only to **how you install** the SDK, not to Swift or this library.
+
+- **SPM:** [Swift Package Index](https://swiftpackageindex.com/contentstack/contentstack-swift) · [GitHub](https://github.com/contentstack/contentstack-swift)
+- **API docs:** [Swift CDA reference](https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/swift/reference)
+- **Background:** [DEPRECATION.md](DEPRECATION.md) · [Docs overview](Docs/overview.md)
 
 Contentstack is a headless CMS with an API-first approach. It is a CMS that developers can use to build powerful cross-platform applications in their favorite languages. Build your application frontend, and Contentstack will take care of the rest. [Read More](https://www.contentstack.com/).
 
@@ -18,7 +25,17 @@ Latest Xcode and Mac OS X
 
 To use this SDK on iOS platform, you will have to install the SDK according to the steps given below.
 
+##### Swift Package Manager
+
+1. In Xcode: **File → Add Package Dependencies…**
+2. Enter `https://github.com/contentstack/contentstack-swift`
+3. Add the **ContentstackSwift** product to your target.
+
+See also the [Swift Package Index listing](https://swiftpackageindex.com/contentstack/contentstack-swift).
+
 ##### CocoaPods
+
+> **Note:** Not recommended for **new** projects—use **SPM** above. Existing Podfile users can keep the pod; see [DEPRECATION.md](DEPRECATION.md).
 
 1. Add the following line to your Podfile:
 2. pod 'ContentstackSwift'


### PR DESCRIPTION
recommend Swift Package Manager for new integrations.