### PR TITLE
Feat:Add Contentstack endpoint resolution and caching mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 build/
 DerivedData/
 
+## Regions registry — downloaded at runtime, never committed
+Sources/Resources/regions.json
+
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+
+## v2.4.0
+
+### Date: 29-Jun-2026
+
+### Enhancement
+
+- Feature: Dynamic endpoint resolution via `Endpoint.getContentstackEndpoint()` and `Builder.setRegion()` backed by the Contentstack Regions Registry.
+
 ## v2.3.4
 
 ### Date: 12-Jun-2026

--- a/ContentstackSwift.xcodeproj/project.pbxproj
+++ b/ContentstackSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07D4EAA86F9B2E5767FD59C0 /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
 		0F0246662431F37300F72181 /* ImageTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0246652431F37300F72181 /* ImageTransform.swift */; };
 		0F0246672431F37300F72181 /* ImageTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0246652431F37300F72181 /* ImageTransform.swift */; };
 		0F0246682431F37300F72181 /* ImageTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0246652431F37300F72181 /* ImageTransform.swift */; };
@@ -233,6 +234,10 @@
 		0FFBB44C24470C43000D2795 /* ContentStackLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FFBB44B24470C43000D2795 /* ContentStackLogTest.swift */; };
 		0FFBB44D24470C43000D2795 /* ContentStackLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FFBB44B24470C43000D2795 /* ContentStackLogTest.swift */; };
 		0FFBB44E24470C43000D2795 /* ContentStackLogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FFBB44B24470C43000D2795 /* ContentStackLogTest.swift */; };
+		113AAA07AE7AA0BA034DD15C /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
+		15FD93907FC5DAD64CAE19DA /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
+		2033A30A37D4CB6CB5B7596A /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
+		448BC0C2CF776AC852CF2790 /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
 		470253932C0C612A009BDF8B /* TaxonomyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470253922C0C612A009BDF8B /* TaxonomyModel.swift */; };
 		470253942C0C612A009BDF8B /* TaxonomyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470253922C0C612A009BDF8B /* TaxonomyModel.swift */; };
 		470253952C0C612A009BDF8B /* TaxonomyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470253922C0C612A009BDF8B /* TaxonomyModel.swift */; };
@@ -309,6 +314,10 @@
 		67BA83032F6D36F3005006B8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = 67BA83022F6D36ED005006B8 /* config.json */; };
 		67BA83042F6D36F3005006B8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = 67BA83022F6D36ED005006B8 /* config.json */; };
 		67BA83052F6D36F3005006B8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = 67BA83022F6D36ED005006B8 /* config.json */; };
+		67BF4D832FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */; };
+		67BF4D842FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */; };
+		67BF4D852FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */; };
+		67BF4D862FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */; };
 		67EE21DF2DDB4013005AC119 /* CSURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EE21DE2DDB3FFE005AC119 /* CSURLSessionDelegate.swift */; };
 		67EE21E02DDB4013005AC119 /* CSURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EE21DE2DDB3FFE005AC119 /* CSURLSessionDelegate.swift */; };
 		67EE21E12DDB4013005AC119 /* CSURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EE21DE2DDB3FFE005AC119 /* CSURLSessionDelegate.swift */; };
@@ -331,6 +340,11 @@
 		67EE22672DE719B6005AC119 /* GlobalField.json in Resources */ = {isa = PBXBuildFile; fileRef = 67EE22622DE719B6005AC119 /* GlobalField.json */; };
 		67EE22682DE719B6005AC119 /* GlobalField.json in Resources */ = {isa = PBXBuildFile; fileRef = 67EE22622DE719B6005AC119 /* GlobalField.json */; };
 		67EE22692DE719B6005AC119 /* GlobalField.json in Resources */ = {isa = PBXBuildFile; fileRef = 67EE22622DE719B6005AC119 /* GlobalField.json */; };
+		891A4066E35CA6FD2782C435 /* ContentstackEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121463DD4870CDCE5E29285C /* ContentstackEndpointTest.swift */; };
+		AD0C3EE700836D51D924C4BC /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
+		EC76C5659459BE40A5B2E7B2 /* ContentstackEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121463DD4870CDCE5E29285C /* ContentstackEndpointTest.swift */; };
+		EE0DA463C63B6F13D86583B2 /* ContentstackEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 121463DD4870CDCE5E29285C /* ContentstackEndpointTest.swift */; };
+		F94602FB037F99115028D162 /* Regions.json in Resources */ = {isa = PBXBuildFile; fileRef = 496CCA811550555D6CE9ABEA /* Regions.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -444,6 +458,7 @@
 		0FFB22B3261C98E50056AEE0 /* .env */ = {isa = PBXFileReference; lastKnownFileType = text; path = .env; sourceTree = "<group>"; };
 		0FFBB4462446F9A4000D2795 /* Asset.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Asset.json; sourceTree = "<group>"; };
 		0FFBB44B24470C43000D2795 /* ContentStackLogTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentStackLogTest.swift; sourceTree = "<group>"; };
+		121463DD4870CDCE5E29285C /* ContentstackEndpointTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContentstackEndpointTest.swift; sourceTree = "<group>"; };
 		470253922C0C612A009BDF8B /* TaxonomyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxonomyModel.swift; sourceTree = "<group>"; };
 		470657532B5E785C00BBFF88 /* ContentTypeQueryAPITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentTypeQueryAPITest.swift; sourceTree = "<group>"; };
 		470657572B5E788400BBFF88 /* EntryAPITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryAPITest.swift; sourceTree = "<group>"; };
@@ -458,6 +473,7 @@
 		47B09C242CA952E400B8AB41 /* DVR.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DVR.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		47B4DC612C232A8200370CFC /* TaxonomyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxonomyTest.swift; sourceTree = "<group>"; };
 		47C6EFC12C0B5B9400F0D5CF /* Taxonomy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Taxonomy.swift; sourceTree = "<group>"; };
+		496CCA811550555D6CE9ABEA /* Regions.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = Regions.json; sourceTree = "<group>"; };
 		672F76982E55ADBE00C248D6 /* AsyncAwaitAPITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAwaitAPITest.swift; sourceTree = "<group>"; };
 		678CBD062EF10CBA00B72390 /* ContentstackMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentstackMessages.swift; sourceTree = "<group>"; };
 		67AA38E92EB9D44800C0E2C0 /* CSDefinitionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSDefinitionsTest.swift; sourceTree = "<group>"; };
@@ -473,6 +489,7 @@
 		67AA39112EBA063300C0E2C0 /* TaxonomyUnitTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaxonomyUnitTest.swift; sourceTree = "<group>"; };
 		67AA39152EBA065000C0E2C0 /* StackInitializationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackInitializationTest.swift; sourceTree = "<group>"; };
 		67BA83022F6D36ED005006B8 /* config.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = config.json; sourceTree = "<group>"; };
+		67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentstackEndpoint.swift; sourceTree = "<group>"; };
 		67EE21DE2DDB3FFE005AC119 /* CSURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSURLSessionDelegate.swift; sourceTree = "<group>"; };
 		67EE222B2DE4868F005AC119 /* GlobalField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalField.swift; sourceTree = "<group>"; };
 		67EE22302DE58B51005AC119 /* GlobalFieldModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalFieldModel.swift; sourceTree = "<group>"; };
@@ -558,6 +575,7 @@
 		0F096B122435BF930094F042 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				67BF4D822FE53F4D00DD4DFC /* ContentstackEndpoint.swift */,
 				0F244FA124406A2D003C3F26 /* SyncStack.swift */,
 				0FFA5D7E241F7060003B3AF5 /* SystemFields.swift */,
 				0F4A245B24224D3100159C24 /* ContentstackResponse.swift */,
@@ -601,6 +619,7 @@
 				0F244F9C244062B4003C3F26 /* ContentType.json */,
 				0F1DCC77243D9BBF00EED404 /* SyncTest.json */,
 				0F5794C1266A37120082815C /* Paragraph.Json */,
+				496CCA811550555D6CE9ABEA /* Regions.json */,
 			);
 			name = DVRRecording;
 			path = DVRRecordings;
@@ -728,6 +747,7 @@
 				0F77CFB724373B8A00C57764 /* ImageTransformEquatableTest.swift */,
 				0F463112243B044F001CE1FA /* SyncTest.swift */,
 				0FFBB44B24470C43000D2795 /* ContentStackLogTest.swift */,
+				121463DD4870CDCE5E29285C /* ContentstackEndpointTest.swift */,
 			);
 			name = UnitTests;
 			sourceTree = "<group>";
@@ -958,8 +978,6 @@
 			dependencies = (
 			);
 			name = "ContentstackSwift tvOS";
-			packageProductDependencies = (
-			);
 			productName = "Contentstack tvOS";
 			productReference = 0F4A7607241BAFE000E3A024 /* ContentstackSwift.framework */;
 			productType = "com.apple.product-type.framework";
@@ -996,8 +1014,6 @@
 			dependencies = (
 			);
 			name = "ContentstackSwift watchOS";
-			packageProductDependencies = (
-			);
 			productName = "Contentstack watchOS";
 			productReference = 0F4A7623241BB0A300E3A024 /* ContentstackSwift.framework */;
 			productType = "com.apple.product-type.framework";
@@ -1081,6 +1097,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67EE22662DE719B6005AC119 /* GlobalField.json in Resources */,
+				448BC0C2CF776AC852CF2790 /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1096,6 +1113,7 @@
 				0F359992257BE2A700B3DB89 /* ContentType.json in Resources */,
 				67EE22692DE719B6005AC119 /* GlobalField.json in Resources */,
 				0F5794C2266A37120082815C /* Paragraph.Json in Resources */,
+				113AAA07AE7AA0BA034DD15C /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1104,6 +1122,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67EE22682DE719B6005AC119 /* GlobalField.json in Resources */,
+				2033A30A37D4CB6CB5B7596A /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1119,6 +1138,7 @@
 				0F796C532449EA8700EA04D5 /* Entry.json in Resources */,
 				67EE22652DE719B6005AC119 /* GlobalField.json in Resources */,
 				0F5794C3266A37120082815C /* Paragraph.Json in Resources */,
+				15FD93907FC5DAD64CAE19DA /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1127,6 +1147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67EE22642DE719B6005AC119 /* GlobalField.json in Resources */,
+				AD0C3EE700836D51D924C4BC /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1142,6 +1163,7 @@
 				0F796C542449EA8700EA04D5 /* Entry.json in Resources */,
 				67EE22672DE719B6005AC119 /* GlobalField.json in Resources */,
 				0F5794C4266A37120082815C /* Paragraph.Json in Resources */,
+				07D4EAA86F9B2E5767FD59C0 /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1150,6 +1172,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67EE22632DE719B6005AC119 /* GlobalField.json in Resources */,
+				F94602FB037F99115028D162 /* Regions.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1169,6 +1192,7 @@
 				0FFA5D7A241F7033003B3AF5 /* ContentType.swift in Sources */,
 				0F0246662431F37300F72181 /* ImageTransform.swift in Sources */,
 				67EE222C2DE48695005AC119 /* GlobalField.swift in Sources */,
+				67BF4D842FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */,
 				0F4FBCA42420B5F4007B8CAE /* Utils.swift in Sources */,
 				0F4C0A7C243C4579006604B7 /* Error.swift in Sources */,
 				0F4C0A81243C470F006604B7 /* ContentstackLogger.swift in Sources */,
@@ -1249,6 +1273,7 @@
 				67AA39002EB9D47800C0E2C0 /* ImageTransformErrorTest.swift in Sources */,
 				0F38D7E0242C7C9E00232D7F /* Product.swift in Sources */,
 				0F38D7E4242C831300232D7F /* AssetTest.swift in Sources */,
+				891A4066E35CA6FD2782C435 /* ContentstackEndpointTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1265,6 +1290,7 @@
 				0FFA5D7B241F7033003B3AF5 /* ContentType.swift in Sources */,
 				0F0246672431F37300F72181 /* ImageTransform.swift in Sources */,
 				67EE222F2DE48695005AC119 /* GlobalField.swift in Sources */,
+				67BF4D832FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */,
 				0F4FBCA52420B5F4007B8CAE /* Utils.swift in Sources */,
 				0F4C0A7D243C4584006604B7 /* Error.swift in Sources */,
 				0F4C0A82243C470F006604B7 /* ContentstackLogger.swift in Sources */,
@@ -1345,6 +1371,7 @@
 				67AA38FF2EB9D47800C0E2C0 /* ImageTransformErrorTest.swift in Sources */,
 				0F38D7E1242C7C9E00232D7F /* Product.swift in Sources */,
 				0F38D7E5242C831A00232D7F /* AssetTest.swift in Sources */,
+				EE0DA463C63B6F13D86583B2 /* ContentstackEndpointTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1361,6 +1388,7 @@
 				0FFA5D7C241F7033003B3AF5 /* ContentType.swift in Sources */,
 				0F0246682431F37300F72181 /* ImageTransform.swift in Sources */,
 				67EE222D2DE48695005AC119 /* GlobalField.swift in Sources */,
+				67BF4D852FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */,
 				0F4FBCA62420B5F4007B8CAE /* Utils.swift in Sources */,
 				0F4C0A7E243C4585006604B7 /* Error.swift in Sources */,
 				0F4C0A83243C470F006604B7 /* ContentstackLogger.swift in Sources */,
@@ -1441,6 +1469,7 @@
 				67AA38FE2EB9D47800C0E2C0 /* ImageTransformErrorTest.swift in Sources */,
 				0F38D7E2242C7C9E00232D7F /* Product.swift in Sources */,
 				0F38D7E6242C831B00232D7F /* AssetTest.swift in Sources */,
+				EC76C5659459BE40A5B2E7B2 /* ContentstackEndpointTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1457,6 +1486,7 @@
 				0FFA5D7D241F7033003B3AF5 /* ContentType.swift in Sources */,
 				0F0246692431F37300F72181 /* ImageTransform.swift in Sources */,
 				67EE222E2DE48695005AC119 /* GlobalField.swift in Sources */,
+				67BF4D862FE53F4D00DD4DFC /* ContentstackEndpoint.swift in Sources */,
 				0F4FBCA72420B5F4007B8CAE /* Utils.swift in Sources */,
 				0F4C0A7F243C4586006604B7 /* Error.swift in Sources */,
 				0F4C0A84243C470F006604B7 /* ContentstackLogger.swift in Sources */,

--- a/Sources/Contentstack.swift
+++ b/Sources/Contentstack.swift
@@ -39,7 +39,7 @@ public struct Contentstack {
                              apiVersion: String = "v3",
                              branch: String? = nil,
                              config: ContentstackConfig = ContentstackConfig.default) -> Stack {
-        let regionBaseHost = host != Host.delivery ? host : (region != .us ? "\(region.rawValue)-cdn.contentstack.com": host)
+        let regionBaseHost = resolveDeliveryHost(region: region, host: host)
         return Stack(apiKey: apiKey,
                      deliveryToken: deliveryToken,
                      environment: environment,
@@ -50,6 +50,53 @@ public struct Contentstack {
                      config: config)
     }
     
+    /// Resolves the content-delivery host for the given region.
+    ///
+    /// An explicitly provided `host` (anything other than the default `Host.delivery`) always wins.
+    /// Otherwise the host is resolved from ``ContentstackEndpoint`` using only already-cached data
+    /// (`allowDownload: false`) so stack creation never blocks on the network. When nothing is cached
+    /// yet, the legacy `<region>-cdn.contentstack.com` pattern is used — it produces the same
+    /// content-delivery host as the registry for every current region.
+    private static func resolveDeliveryHost(region: ContentstackRegion, host: String) -> String {
+        if host != Host.delivery {
+            return host
+        }
+        if let resolved = try? ContentstackEndpoint.getContentstackEndpoint(region.rawValue,
+                                                                            service: "contentDelivery",
+                                                                            omitHttps: true,
+                                                                            allowDownload: false) {
+            return resolved
+        }
+        // Nothing cached / unrecognised region: fall back to the legacy prefix pattern.
+        return region != .us ? "\(region.rawValue)-cdn.contentstack.com" : host
+    }
+
+    /// Returns the Contentstack API URL for the given region and service.
+    ///
+    /// - Parameters:
+    ///   - region: region ID or alias (e.g. `"na"`, `"eu"`, `"azure-na"`).
+    ///   - service: service key (e.g. `"contentDelivery"`, `"contentManagement"`).
+    ///   - omitHttps: when `true`, returns the bare host without the `https://` prefix.
+    /// - Returns: the URL (or bare host when `omitHttps` is `true`).
+    /// - Throws: ``EndpointError`` if the region or service is not recognised.
+    public static func getContentstackEndpoint(region: String,
+                                               service: String,
+                                               omitHttps: Bool = false) throws -> String {
+        return try ContentstackEndpoint.getContentstackEndpoint(region, service: service, omitHttps: omitHttps)
+    }
+
+    /// Returns all service endpoints for the given region as a map of service key to URL.
+    ///
+    /// - Parameters:
+    ///   - region: region ID or alias.
+    ///   - omitHttps: when `true`, returns bare hosts without the `https://` prefix.
+    /// - Returns: map of service key → URL (or bare host).
+    /// - Throws: ``EndpointError`` if the region is not recognised.
+    public static func getContentstackEndpoints(region: String,
+                                                omitHttps: Bool = false) throws -> [String: String] {
+        return try ContentstackEndpoint.getContentstackEndpoints(region, omitHttps: omitHttps)
+    }
+
     public struct Utils {
         public static func render(content: String, option: Option) throws -> String {
             return try ContentstackUtils.render(content: content, option)

--- a/Sources/ContentstackEndpoint.swift
+++ b/Sources/ContentstackEndpoint.swift
@@ -1,0 +1,263 @@
+//
+//  ContentstackEndpoint.swift
+//  Contentstack
+//
+//  Resolves Contentstack API endpoints for any region and service without
+//  hardcoding host strings. Region data is fetched from the Contentstack
+//  artifacts registry at runtime and cached (in memory and on disk).
+//
+
+import Foundation
+
+/// Errors thrown while resolving a Contentstack endpoint.
+public enum EndpointError: Error, CustomStringConvertible, LocalizedError, Equatable {
+    /// The region argument was empty (or whitespace only).
+    case emptyRegion
+    /// The region did not match any known canonical ID or alias.
+    case invalidRegion(String)
+    /// The requested service key was not present for the resolved region.
+    case serviceNotFound(service: String, region: String)
+    /// The regions registry could not be loaded from cache and could not be downloaded.
+    case regionsUnavailable
+
+    public var description: String {
+        switch self {
+        case .emptyRegion:
+            return "Empty region provided. Please provide a valid region."
+        case .invalidRegion(let region):
+            return "Invalid region: \(region)"
+        case .serviceNotFound(let service, let region):
+            return "Service \"\(service)\" not found for region \"\(region)\""
+        case .regionsUnavailable:
+            return "Could not load the regions registry from cache and could not download it from "
+                + "\(ContentstackEndpoint.regionsURL). Check network access."
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
+/// Resolves Contentstack API endpoints for any region and service.
+///
+/// Resolution chain:
+/// 1. **In-memory cache** — populated on the first successful load and reused for the process lifetime.
+/// 2. **On-disk cache** — a previously downloaded copy stored in the caches directory, so subsequent
+///    processes do not need to hit the network.
+/// 3. **Live download** — fetched from ``regionsURL`` and written to the on-disk cache. Attempted at
+///    most once per process.
+///
+/// The registry is **not** bundled with the SDK; it is downloaded on first use. Region matching is
+/// case-insensitive and treats `-` and `_` as equivalent separators, so `"AZURE_NA"`, `"azure-na"`,
+/// and `"Azure_NA"` all resolve to the same region.
+///
+/// ```swift
+/// let url  = try ContentstackEndpoint.getContentstackEndpoint("eu", service: "contentDelivery")
+/// // → "https://eu-cdn.contentstack.com"
+///
+/// let host = try ContentstackEndpoint.getContentstackEndpoint("eu", service: "contentDelivery", omitHttps: true)
+/// // → "eu-cdn.contentstack.com"
+///
+/// let all  = try ContentstackEndpoint.getContentstackEndpoints("azure-na")
+/// // → ["contentDelivery": "https://azure-na-cdn.contentstack.com", ...]
+/// ```
+public enum ContentstackEndpoint {
+
+    /// The live registry URL used to download region data.
+    public static let regionsURL = "https://artifacts.contentstack.com/regions.json"
+
+    private static var regionsCache: [[String: Any]]?
+    // Ensures the live download is attempted at most once per process so that genuinely
+    // invalid region strings do not trigger repeated network calls.
+    private static var liveRefreshDone = false
+    // Allows tests to disable the network fallback.
+    static var isLiveRefreshEnabled = true
+    // Allows tests to bypass the on-disk cache so the download path can be exercised deterministically.
+    static var isDiskCacheEnabled = true
+    // The session used to download the registry. Overridable so tests can inject a DVR session.
+    static var session: URLSession = .shared
+    private static let lock = NSLock()
+
+    // MARK: - Public API
+
+    /// Returns the URL for the given region and service.
+    ///
+    /// - Parameters:
+    ///   - region: region ID or alias (e.g. `"na"`, `"eu"`, `"azure-na"`).
+    ///   - service: service key (e.g. `"contentDelivery"`, `"contentManagement"`).
+    ///   - omitHttps: when `true`, returns the bare host without the `https://` prefix.
+    ///   - allowDownload: when `true` (default), the registry may be downloaded if not already
+    ///     cached. Pass `false` to resolve only from cache without any network access.
+    /// - Returns: the full URL (or bare host when `omitHttps` is `true`).
+    /// - Throws: ``EndpointError`` if the region or service is not recognised, or the registry is
+    ///   unavailable.
+    public static func getContentstackEndpoint(_ region: String,
+                                               service: String,
+                                               omitHttps: Bool = false,
+                                               allowDownload: Bool = true) throws -> String {
+        if region.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw EndpointError.emptyRegion
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        let row = try resolveRegion(region, allowDownload: allowDownload)
+        guard let endpoints = row["endpoints"] as? [String: Any] else {
+            throw EndpointError.serviceNotFound(service: service, region: region)
+        }
+        guard let url = endpoints[service] as? String else {
+            throw EndpointError.serviceNotFound(service: service, region: region)
+        }
+        return omitHttps ? stripHttps(url) : url
+    }
+
+    /// Returns all endpoints for the given region as a map of service key to URL.
+    ///
+    /// - Parameters:
+    ///   - region: region ID or alias.
+    ///   - omitHttps: when `true`, returns bare hosts without the `https://` prefix.
+    ///   - allowDownload: when `true` (default), the registry may be downloaded if not already cached.
+    /// - Returns: map of service key → URL (or bare host).
+    /// - Throws: ``EndpointError`` if the region is not recognised, or the registry is unavailable.
+    public static func getContentstackEndpoints(_ region: String,
+                                                omitHttps: Bool = false,
+                                                allowDownload: Bool = true) throws -> [String: String] {
+        if region.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw EndpointError.emptyRegion
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        let row = try resolveRegion(region, allowDownload: allowDownload)
+        guard let endpoints = row["endpoints"] as? [String: Any] else {
+            throw EndpointError.invalidRegion(region)
+        }
+        var result = [String: String]()
+        for (key, value) in endpoints {
+            if let url = value as? String {
+                result[key] = omitHttps ? stripHttps(url) : url
+            }
+        }
+        return result
+    }
+
+    /// Resets the in-memory cache and the live-refresh flag. Intended for testing only.
+    static func resetCache() {
+        lock.lock()
+        defer { lock.unlock() }
+        regionsCache = nil
+        liveRefreshDone = false
+    }
+
+    // MARK: - Internals (callers must hold `lock`)
+
+    /// Resolution chain: cache / disk, then a one-time live refresh when the region is absent and
+    /// downloads are permitted.
+    private static func resolveRegion(_ region: String, allowDownload: Bool) throws -> [String: Any] {
+        let regions = try loadRegions(allowDownload: allowDownload)
+        do {
+            return try findRegion(regions, region)
+        } catch let notFound {
+            // Region absent from the cached data — attempt one live refresh in case Contentstack
+            // added a region since the cache was written.
+            if allowDownload, !liveRefreshDone, isLiveRefreshEnabled,
+               let fresh = tryLiveRefresh(), let row = try? findRegion(fresh, region) {
+                return row
+            }
+            throw notFound
+        }
+    }
+
+    /// Loads regions from the in-memory cache, the on-disk cache, or a live download (in that order).
+    private static func loadRegions(allowDownload: Bool) throws -> [[String: Any]] {
+        if let cache = regionsCache {
+            return cache
+        }
+        if let data = diskCacheData(), let regions = parseRegions(data) {
+            regionsCache = regions
+            return regions
+        }
+        if allowDownload, let downloaded = tryLiveRefresh() {
+            return downloaded
+        }
+        throw EndpointError.regionsUnavailable
+    }
+
+    /// Attempts a one-time HTTP fetch of ``regionsURL``. Returns the parsed regions on success, or
+    /// `nil` if skipped/unavailable. Updates the in-memory cache and the on-disk cache on success.
+    private static func tryLiveRefresh() -> [[String: Any]]? {
+        if liveRefreshDone || !isLiveRefreshEnabled {
+            return regionsCache
+        }
+        liveRefreshDone = true
+        guard let url = URL(string: regionsURL) else { return nil }
+        var request = URLRequest(url: url, timeoutInterval: 10)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var fetchedData: Data?
+        let task = session.dataTask(with: request) { data, _, _ in
+            fetchedData = data
+            semaphore.signal()
+        }
+        task.resume()
+        _ = semaphore.wait(timeout: .now() + 12)
+
+        guard let data = fetchedData, let regions = parseRegions(data) else { return nil }
+        regionsCache = regions
+        if isDiskCacheEnabled, let cacheURL = diskCacheURL {
+            try? data.write(to: cacheURL, options: .atomic)
+        }
+        return regions
+    }
+
+    private static var diskCacheURL: URL? {
+        guard let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        return dir.appendingPathComponent("com.contentstack.swift.regions.json")
+    }
+
+    private static func diskCacheData() -> Data? {
+        guard isDiskCacheEnabled, let url = diskCacheURL else { return nil }
+        return try? Data(contentsOf: url)
+    }
+
+    private static func parseRegions(_ data: Data) -> [[String: Any]]? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let regions = object["regions"] as? [[String: Any]] else {
+            return nil
+        }
+        return regions
+    }
+
+    private static func findRegion(_ regions: [[String: Any]], _ region: String) throws -> [String: Any] {
+        let normalized = normalize(region)
+
+        // Pass 1: match canonical id.
+        for row in regions {
+            if let id = row["id"] as? String, normalize(id) == normalized {
+                return row
+            }
+        }
+        // Pass 2: match aliases (case-insensitive, `_` == `-`).
+        for row in regions {
+            guard let aliases = row["alias"] as? [String] else { continue }
+            for alias in aliases where normalize(alias) == normalized {
+                return row
+            }
+        }
+        throw EndpointError.invalidRegion(region)
+    }
+
+    private static func normalize(_ value: String) -> String {
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+    }
+
+    private static func stripHttps(_ url: String) -> String {
+        if let range = url.range(of: "^https?://", options: .regularExpression) {
+            return String(url[range.upperBound...])
+        }
+        return url
+    }
+}

--- a/Tests/ContentstackEndpointTest.swift
+++ b/Tests/ContentstackEndpointTest.swift
@@ -1,0 +1,186 @@
+//
+//  ContentstackEndpointTest.swift
+//  Contentstack
+//
+//  Tests for region/service endpoint resolution via ContentstackEndpoint.
+//
+
+import XCTest
+import DVR
+@testable import ContentstackSwift
+
+class ContentstackEndpointTest: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        ContentstackEndpoint.resetCache()
+        // Resolve region data offline by replaying the recorded artifacts.contentstack.com response
+        // through a DVR cassette, exactly like the other API tests. Disable the on-disk cache so the
+        // download path is exercised deterministically every run.
+        ContentstackEndpoint.isDiskCacheEnabled = false
+        ContentstackEndpoint.isLiveRefreshEnabled = true
+        let dvrSession = DVR.Session(cassetteName: "Regions")
+        dvrSession.recordingEnabled = false
+        ContentstackEndpoint.session = dvrSession
+    }
+
+    override func tearDown() {
+        ContentstackEndpoint.resetCache()
+        ContentstackEndpoint.session = .shared
+        ContentstackEndpoint.isDiskCacheEnabled = true
+        ContentstackEndpoint.isLiveRefreshEnabled = true
+        super.tearDown()
+    }
+
+    // MARK: - Basic resolution
+
+    func testContentDelivery_na() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("na", service: "contentDelivery"),
+                       "https://cdn.contentstack.io")
+    }
+
+    func testContentDelivery_eu() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("eu", service: "contentDelivery"),
+                       "https://eu-cdn.contentstack.com")
+    }
+
+    func testContentManagement_azureNa() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("azure-na", service: "contentManagement"),
+                       "https://azure-na-api.contentstack.com")
+    }
+
+    func testGraphqlDelivery_gcpEu() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("gcp-eu", service: "graphqlDelivery"),
+                       "https://gcp-eu-graphql.contentstack.com")
+    }
+
+    // MARK: - omitHttps
+
+    func testOmitHttps_stripsScheme() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("eu", service: "contentDelivery", omitHttps: true),
+                       "eu-cdn.contentstack.com")
+    }
+
+    func testOmitHttps_naDefault() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("na", service: "contentDelivery", omitHttps: true),
+                       "cdn.contentstack.io")
+    }
+
+    // MARK: - Alias / normalization
+
+    func testAliases_resolveToNa() throws {
+        for alias in ["na", "us", "aws-na", "aws_na", "NA", "US", "AWS-NA", "AWS_NA"] {
+            XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint(alias, service: "contentDelivery"),
+                           "https://cdn.contentstack.io", "alias \(alias) should resolve to na")
+        }
+    }
+
+    func testAliases_underscoreEqualsHyphen() throws {
+        let hyphen = try ContentstackEndpoint.getContentstackEndpoint("azure-na", service: "contentDelivery")
+        let underscore = try ContentstackEndpoint.getContentstackEndpoint("azure_na", service: "contentDelivery")
+        XCTAssertEqual(hyphen, underscore)
+    }
+
+    func testWhitespaceTrimmed() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("  eu  ", service: "contentDelivery"),
+                       "https://eu-cdn.contentstack.com")
+    }
+
+    // MARK: - All endpoints
+
+    func testGetAllEndpoints_containsKeys() throws {
+        let all = try ContentstackEndpoint.getContentstackEndpoints("eu")
+        XCTAssertEqual(all["contentDelivery"], "https://eu-cdn.contentstack.com")
+        XCTAssertEqual(all["contentManagement"], "https://eu-api.contentstack.com")
+        XCTAssertEqual(all["auth"], "https://eu-auth-api.contentstack.com")
+    }
+
+    func testGetAllEndpoints_omitHttps() throws {
+        let all = try ContentstackEndpoint.getContentstackEndpoints("eu", omitHttps: true)
+        XCTAssertEqual(all["contentDelivery"], "eu-cdn.contentstack.com")
+    }
+
+    func testAssetManagement_naOnly() throws {
+        XCTAssertEqual(try ContentstackEndpoint.getContentstackEndpoint("na", service: "assetManagement"),
+                       "https://am-api.contentstack.com")
+        // assetManagement is not present for eu.
+        XCTAssertThrowsError(try ContentstackEndpoint.getContentstackEndpoint("eu", service: "assetManagement"))
+    }
+
+    // MARK: - Errors
+
+    func testEmptyRegionThrows() {
+        XCTAssertThrowsError(try ContentstackEndpoint.getContentstackEndpoint("", service: "contentDelivery")) { error in
+            XCTAssertEqual(error as? EndpointError, .emptyRegion)
+        }
+    }
+
+    func testUnknownServiceThrows() {
+        XCTAssertThrowsError(try ContentstackEndpoint.getContentstackEndpoint("na", service: "cms")) { error in
+            XCTAssertEqual(error as? EndpointError, .serviceNotFound(service: "cms", region: "na"))
+        }
+    }
+
+    func testInvalidRegionThrows() {
+        XCTAssertThrowsError(try ContentstackEndpoint.getContentstackEndpoint("asia-pacific", service: "contentDelivery")) { error in
+            XCTAssertEqual(error as? EndpointError, .invalidRegion("asia-pacific"))
+        }
+    }
+
+    // MARK: - Contentstack convenience proxy
+
+    func testContentstackProxy_matchesEndpoint() throws {
+        XCTAssertEqual(try Contentstack.getContentstackEndpoint(region: "eu", service: "contentDelivery"),
+                       try ContentstackEndpoint.getContentstackEndpoint("eu", service: "contentDelivery"))
+    }
+
+    func testContentstackProxy_allEndpoints() throws {
+        let all = try Contentstack.getContentstackEndpoints(region: "na")
+        XCTAssertEqual(all["contentDelivery"], "https://cdn.contentstack.io")
+    }
+
+    // MARK: - Stack host wiring
+
+    func testStackHost_resolvedFromRegion() {
+        let regions: [(ContentstackRegion, String)] = [
+            (.us, "cdn.contentstack.io"),
+            (.eu, "eu-cdn.contentstack.com"),
+            (.au, "au-cdn.contentstack.com"),
+            (.azure_na, "azure-na-cdn.contentstack.com"),
+            (.azure_eu, "azure-eu-cdn.contentstack.com"),
+            (.gcp_na, "gcp-na-cdn.contentstack.com"),
+            (.gcp_eu, "gcp-eu-cdn.contentstack.com")
+        ]
+        for (region, expectedHost) in regions {
+            let stack = makeStackSut(region: region)
+            XCTAssertEqual(stack.host, expectedHost, "host for region \(region)")
+        }
+    }
+
+    func testStackHost_explicitHostWins() {
+        let stack = makeStackSut(region: .eu, host: "custom.example.com")
+        XCTAssertEqual(stack.host, "custom.example.com")
+    }
+
+    static var allTests = [
+        ("testContentDelivery_na", testContentDelivery_na),
+        ("testContentDelivery_eu", testContentDelivery_eu),
+        ("testContentManagement_azureNa", testContentManagement_azureNa),
+        ("testGraphqlDelivery_gcpEu", testGraphqlDelivery_gcpEu),
+        ("testOmitHttps_stripsScheme", testOmitHttps_stripsScheme),
+        ("testOmitHttps_naDefault", testOmitHttps_naDefault),
+        ("testAliases_resolveToNa", testAliases_resolveToNa),
+        ("testAliases_underscoreEqualsHyphen", testAliases_underscoreEqualsHyphen),
+        ("testWhitespaceTrimmed", testWhitespaceTrimmed),
+        ("testGetAllEndpoints_containsKeys", testGetAllEndpoints_containsKeys),
+        ("testGetAllEndpoints_omitHttps", testGetAllEndpoints_omitHttps),
+        ("testAssetManagement_naOnly", testAssetManagement_naOnly),
+        ("testEmptyRegionThrows", testEmptyRegionThrows),
+        ("testUnknownServiceThrows", testUnknownServiceThrows),
+        ("testInvalidRegionThrows", testInvalidRegionThrows),
+        ("testContentstackProxy_matchesEndpoint", testContentstackProxy_matchesEndpoint),
+        ("testContentstackProxy_allEndpoints", testContentstackProxy_allEndpoints),
+        ("testStackHost_resolvedFromRegion", testStackHost_resolvedFromRegion),
+        ("testStackHost_explicitHostWins", testStackHost_explicitHostWins)
+    ]
+}

--- a/Tests/DVRRecordings/Regions.json
+++ b/Tests/DVRRecordings/Regions.json
@@ -1,0 +1,238 @@
+{
+  "name": "Regions",
+  "interactions": [
+    {
+      "request": {
+        "url": "https://artifacts.contentstack.com/regions.json",
+        "method": "GET",
+        "headers": {
+          "Accept": "application/json"
+        }
+      },
+      "response": {
+        "url": "https://artifacts.contentstack.com/regions.json",
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "regions": [
+            {
+              "id": "na",
+              "alias": [
+                "na",
+                "us",
+                "aws-na",
+                "aws_na",
+                "NA",
+                "US",
+                "AWS-NA",
+                "AWS_NA"
+              ],
+              "isDefault": true,
+              "endpoints": {
+                "application": "https://app.contentstack.com",
+                "contentDelivery": "https://cdn.contentstack.io",
+                "contentManagement": "https://api.contentstack.io",
+                "auth": "https://auth-api.contentstack.com",
+                "graphqlDelivery": "https://graphql.contentstack.com",
+                "preview": "https://rest-preview.contentstack.com",
+                "graphqlPreview": "https://graphql-preview.contentstack.com",
+                "images": "https://images.contentstack.io",
+                "assets": "https://assets.contentstack.io",
+                "automate": "https://automations-api.contentstack.com",
+                "launch": "https://launch-api.contentstack.com",
+                "developerHub": "https://developerhub-api.contentstack.com",
+                "brandKit": "https://brand-kits-api.contentstack.com",
+                "genAI": "https://ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://personalize-api.contentstack.com",
+                "personalizeEdge": "https://personalize-edge.contentstack.com",
+                "composableStudio": "https://composable-studio-api.contentstack.com",
+                "assetManagement": "https://am-api.contentstack.com"
+              }
+            },
+            {
+              "id": "eu",
+              "alias": [
+                "eu",
+                "aws-eu",
+                "aws_eu",
+                "EU",
+                "AWS-EU",
+                "AWS_EU"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://eu-app.contentstack.com",
+                "contentDelivery": "https://eu-cdn.contentstack.com",
+                "contentManagement": "https://eu-api.contentstack.com",
+                "auth": "https://eu-auth-api.contentstack.com",
+                "graphqlDelivery": "https://eu-graphql.contentstack.com",
+                "preview": "https://eu-rest-preview.contentstack.com",
+                "graphqlPreview": "https://eu-graphql-preview.contentstack.com",
+                "images": "https://eu-images.contentstack.com",
+                "assets": "https://eu-assets.contentstack.com",
+                "automate": "https://eu-prod-automations-api.contentstack.com",
+                "launch": "https://eu-launch-api.contentstack.com",
+                "developerHub": "https://eu-developerhub-api.contentstack.com",
+                "brandKit": "https://eu-brand-kits-api.contentstack.com",
+                "genAI": "https://eu-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://eu-personalize-api.contentstack.com",
+                "personalizeEdge": "https://eu-personalize-edge.contentstack.com",
+                "composableStudio": "https://eu-composable-studio-api.contentstack.com"
+              }
+            },
+            {
+              "id": "au",
+              "alias": [
+                "au",
+                "aws-au",
+                "aws_au",
+                "AU",
+                "AWS-AU",
+                "AWS_AU"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://au-app.contentstack.com",
+                "contentDelivery": "https://au-cdn.contentstack.com",
+                "contentManagement": "https://au-api.contentstack.com",
+                "auth": "https://au-auth-api.contentstack.com",
+                "graphqlDelivery": "https://au-graphql.contentstack.com",
+                "preview": "https://au-rest-preview.contentstack.com",
+                "graphqlPreview": "https://au-graphql-preview.contentstack.com",
+                "images": "https://au-images.contentstack.com",
+                "assets": "https://au-assets.contentstack.com",
+                "automate": "https://au-prod-automations-api.contentstack.com",
+                "launch": "https://au-launch-api.contentstack.com",
+                "developerHub": "https://au-developerhub-api.contentstack.com",
+                "brandKit": "https://au-brand-kits-api.contentstack.com",
+                "genAI": "https://au-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://au-personalize-api.contentstack.com",
+                "personalizeEdge": "https://au-personalize-edge.contentstack.com",
+                "composableStudio": "https://au-composable-studio-api.contentstack.com"
+              }
+            },
+            {
+              "id": "azure-na",
+              "alias": [
+                "azure-na",
+                "azure_na",
+                "AZURE-NA",
+                "AZURE_NA"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://azure-na-app.contentstack.com",
+                "contentDelivery": "https://azure-na-cdn.contentstack.com",
+                "contentManagement": "https://azure-na-api.contentstack.com",
+                "auth": "https://azure-na-auth-api.contentstack.com",
+                "graphqlDelivery": "https://azure-na-graphql.contentstack.com",
+                "preview": "https://azure-na-rest-preview.contentstack.com",
+                "graphqlPreview": "https://azure-na-graphql-preview.contentstack.com",
+                "images": "https://azure-na-images.contentstack.com",
+                "assets": "https://azure-na-assets.contentstack.com",
+                "automate": "https://azure-na-automations-api.contentstack.com",
+                "launch": "https://azure-na-launch-api.contentstack.com",
+                "developerHub": "https://azure-na-developerhub-api.contentstack.com",
+                "brandKit": "https://azure-na-brand-kits-api.contentstack.com",
+                "genAI": "https://azure-na-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://azure-na-personalize-api.contentstack.com",
+                "personalizeEdge": "https://azure-na-personalize-edge.contentstack.com",
+                "composableStudio": "https://azure-na-composable-studio-api.contentstack.com"
+              }
+            },
+            {
+              "id": "azure-eu",
+              "alias": [
+                "azure-eu",
+                "azure_eu",
+                "AZURE-EU",
+                "AZURE_EU"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://azure-eu-app.contentstack.com",
+                "contentDelivery": "https://azure-eu-cdn.contentstack.com",
+                "contentManagement": "https://azure-eu-api.contentstack.com",
+                "auth": "https://azure-eu-auth-api.contentstack.com",
+                "graphqlDelivery": "https://azure-eu-graphql.contentstack.com",
+                "preview": "https://azure-eu-rest-preview.contentstack.com",
+                "graphqlPreview": "https://azure-eu-graphql-preview.contentstack.com",
+                "images": "https://azure-eu-images.contentstack.com",
+                "assets": "https://azure-eu-assets.contentstack.com",
+                "automate": "https://azure-eu-automations-api.contentstack.com",
+                "launch": "https://azure-eu-launch-api.contentstack.com",
+                "developerHub": "https://azure-eu-developerhub-api.contentstack.com",
+                "brandKit": "https://azure-eu-brand-kits-api.contentstack.com",
+                "genAI": "https://azure-eu-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://azure-eu-personalize-api.contentstack.com",
+                "personalizeEdge": "https://azure-eu-personalize-edge.contentstack.com",
+                "composableStudio": "https://azure-eu-composable-studio-api.contentstack.com"
+              }
+            },
+            {
+              "id": "gcp-na",
+              "alias": [
+                "gcp-na",
+                "gcp_na",
+                "GCP-NA",
+                "GCP_NA"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://gcp-na-app.contentstack.com",
+                "contentDelivery": "https://gcp-na-cdn.contentstack.com",
+                "contentManagement": "https://gcp-na-api.contentstack.com",
+                "auth": "https://gcp-na-auth-api.contentstack.com",
+                "graphqlDelivery": "https://gcp-na-graphql.contentstack.com",
+                "preview": "https://gcp-na-rest-preview.contentstack.com",
+                "graphqlPreview": "https://gcp-na-graphql-preview.contentstack.com",
+                "images": "https://gcp-na-images.contentstack.com",
+                "assets": "https://gcp-na-assets.contentstack.com",
+                "automate": "https://gcp-na-automations-api.contentstack.com",
+                "launch": "https://gcp-na-launch-api.contentstack.com",
+                "developerHub": "https://gcp-na-developerhub-api.contentstack.com",
+                "brandKit": "https://gcp-na-brand-kits-api.contentstack.com",
+                "genAI": "https://gcp-na-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://gcp-na-personalize-api.contentstack.com",
+                "personalizeEdge": "https://gcp-na-personalize-edge.contentstack.com",
+                "composableStudio": "https://gcp-na-composable-studio-api.contentstack.com"
+              }
+            },
+            {
+              "id": "gcp-eu",
+              "alias": [
+                "gcp-eu",
+                "gcp_eu",
+                "GCP-EU",
+                "GCP_EU"
+              ],
+              "isDefault": false,
+              "endpoints": {
+                "application": "https://gcp-eu-app.contentstack.com",
+                "contentDelivery": "https://gcp-eu-cdn.contentstack.com",
+                "contentManagement": "https://gcp-eu-api.contentstack.com",
+                "auth": "https://gcp-eu-auth-api.contentstack.com",
+                "graphqlDelivery": "https://gcp-eu-graphql.contentstack.com",
+                "preview": "https://gcp-eu-rest-preview.contentstack.com",
+                "graphqlPreview": "https://gcp-eu-graphql-preview.contentstack.com",
+                "images": "https://gcp-eu-images.contentstack.com",
+                "assets": "https://gcp-eu-assets.contentstack.com",
+                "automate": "https://gcp-eu-automations-api.contentstack.com",
+                "launch": "https://gcp-eu-launch-api.contentstack.com",
+                "developerHub": "https://gcp-eu-developerhub-api.contentstack.com",
+                "brandKit": "https://gcp-eu-brand-kits-api.contentstack.com",
+                "genAI": "https://gcp-eu-ai.contentstack.com/brand-kits",
+                "personalizeManagement": "https://gcp-eu-personalize-api.contentstack.com",
+                "personalizeEdge": "https://gcp-eu-personalize-edge.contentstack.com",
+                "composableStudio": "https://gcp-eu-composable-studio-api.contentstack.com"
+              }
+            }
+          ]
+        }
+      },
+      "recorded_at": 1718000000
+    }
+  ]
+}

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -10,6 +10,7 @@ public func allTests() -> [XCTestCaseEntry] {
         testCase(QueryOperationTest.allTests),
         testCase(QueryParameterTest.allTests),
         testCase(EndPointTest.allTests),
+        testCase(ContentstackEndpointTest.allTests),
         testCase(DecodableTest.allTests),
         testCase(CSDefinitionsTest.allTests),
         testCase(ImageTransformErrorTest.allTests),


### PR DESCRIPTION
- Introduced `ContentstackEndpoint` for resolving API endpoints based on region and service without hardcoding.
- Implemented in-memory and on-disk caching for region data to minimize network calls.
- Added error handling for invalid regions and services.
- Updated `Contentstack` struct to utilize the new endpoint resolution logic.
- Created comprehensive unit tests for endpoint resolution, including alias handling and error cases.
- Added DVR recordings for consistent testing of region data responses.